### PR TITLE
Restart overwrite

### DIFF
--- a/model/src/w3odatmd.F90
+++ b/model/src/w3odatmd.F90
@@ -563,6 +563,7 @@ MODULE W3ODATMD
                                                      !! if runtype is startup or branch run, then initfile is used
   logical            :: use_user_histname = .false.  !<@public logical flag for user set history filenames
   logical            :: use_user_restname = .false.  !<@public logical flag for user set restart filenames
+  logical            :: use_overwrite_protect = .false.  !<@public logical flag for protecting time0/timeN overwrite
   character(len=512) :: user_histfname = ''          !<@public user history filename prefix, timestring
                                                      !! YYYY-MM-DD-SSSSS will be appended
   character(len=512) :: user_restfname = ''          !<@public user restart filename prefix, timestring

--- a/model/src/wav_comp_nuopc.F90
+++ b/model/src/wav_comp_nuopc.F90
@@ -1663,7 +1663,23 @@ contains
     fnmpre = './'
 
     call ESMF_LogWrite(trim(subname)//' call read_shel_config', ESMF_LOGMSG_INFO)
-    call read_shel_config(mpi_comm, mds, time0_overwrite=time0, timen_overwrite=timen)
+    
+
+  ! Added attribute for restart time0/timeN overwrite option
+    call NUOPC_CompAttributeGet(gcomp, name='overwrite_protect', value=cvalue, isPresent=isPresent, isSet=isSet, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (isPresent .and. isSet) then
+      use_overwrite_protect=(trim(cvalue)=="true")
+    end if
+    
+    write(logmsg,'(A,l)') trim(subname)//': time0/timeN overwrite is protected',use_overwrite_protect
+
+    if (use_overwrite_protect) then
+      call read_shel_config(mpi_comm, mds) 
+    else
+      call read_shel_config(mpi_comm, mds, time0_overwrite=time0, timen_overwrite=timen)
+    end if
+    !call read_shel_config(mpi_comm, mds, time0_overwrite=time0, timen_overwrite=timen)
 
     call ESMF_LogWrite(trim(subname)//' call w3init', ESMF_LOGMSG_INFO)
     call w3init ( 1, .false., 'ww3', mds, ntrace, odat, flgrd, flgr2, flgd, flg2, &

--- a/model/src/wav_comp_nuopc.F90
+++ b/model/src/wav_comp_nuopc.F90
@@ -44,7 +44,7 @@ module wav_comp_nuopc
   use wav_shr_mod           , only : wav_coupling_to_cice, nwav_elev_spectrum
   use wav_shr_mod           , only : merge_import, dbug_flag
   use w3odatmd              , only : nds, iaproc, napout
-  use w3odatmd              , only : runtype, use_user_histname, user_histfname, use_user_restname, user_restfname
+  use w3odatmd              , only : runtype, use_user_histname, user_histfname, use_user_restname, user_restfname, use_overwrite_protect
   use w3odatmd              , only : user_netcdf_grdout
   use w3odatmd              , only : time_origin, calendar_name, elapsed_secs
   use wav_shr_mod           , only : casename, multigrid, inst_suffix, inst_index, unstr_mesh
@@ -1642,7 +1642,7 @@ contains
     if (isPresent .and. isSet) then
       use_user_restname=(trim(cvalue)=="true")
     end if
-    write(logmsg,'(A,l)') trim(subname)//': Custom restart names in use ',use_user_restname
+    write(logmsg,'(A,l)') trim(subname)//': Custom restart names in use',use_user_restname
     call ESMF_LogWrite(trim(logmsg), ESMF_LOGMSG_INFO)
 
     call NUOPC_CompAttributeGet(gcomp, name='gridded_netcdfout', value=cvalue, isPresent=isPresent, isSet=isSet, rc=rc)
@@ -1667,19 +1667,19 @@ contains
 
   ! Added attribute for restart time0/timeN overwrite option
     call NUOPC_CompAttributeGet(gcomp, name='overwrite_protect', value=cvalue, isPresent=isPresent, isSet=isSet, rc=rc)
+    
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     if (isPresent .and. isSet) then
       use_overwrite_protect=(trim(cvalue)=="true")
     end if
-    
-    write(logmsg,'(A,l)') trim(subname)//': time0/timeN overwrite is protected',use_overwrite_protect
 
     if (use_overwrite_protect) then
-      call read_shel_config(mpi_comm, mds) 
+            call ESMF_LogWrite(trim(subname)//':  no time0/timeN overwrite')
+            call read_shel_config(mpi_comm, mds) 
     else
-      call read_shel_config(mpi_comm, mds, time0_overwrite=time0, timen_overwrite=timen)
+            call ESMF_LogWrite(trim(subname)//': time0/timeN overwrite')
+            call read_shel_config(mpi_comm, mds, time0_overwrite=time0, timen_overwrite=timen)
     end if
-    !call read_shel_config(mpi_comm, mds, time0_overwrite=time0, timen_overwrite=timen)
 
     call ESMF_LogWrite(trim(subname)//' call w3init', ESMF_LOGMSG_INFO)
     call w3init ( 1, .false., 'ww3', mds, ntrace, odat, flgrd, flgr2, flgd, flg2, &

--- a/model/src/wav_import_export.F90
+++ b/model/src/wav_import_export.F90
@@ -944,6 +944,7 @@ contains
       ! local variables
       type(ESMF_Distgrid) :: distgrid
       type(ESMF_Grid)     :: grid
+      real(ESMF_KIND_R8), pointer :: fldptr2d(:,:)
       character(len=*), parameter :: subname='(wav_import_export:SetScalarField)'
       ! ----------------------------------------------
 
@@ -959,6 +960,11 @@ contains
       field = ESMF_FieldCreate(name=trim(flds_scalar_name), grid=grid, typekind=ESMF_TYPEKIND_R8, &
            ungriddedLBound=(/1/), ungriddedUBound=(/flds_scalar_num/), gridToFieldMap=(/2/), rc=rc) ! num of scalar values
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
+
+      ! initialize fldptr to zero
+      call ESMF_FieldGet(field, farrayPtr=fldptr2d, rc=rc)
+      if (ChkErr(rc,__LINE__,u_FILE_u)) return
+      fldptr2d(:,:) = 0.0
 
     end subroutine SetScalarField
 


### PR DESCRIPTION
# Pull Request Summary
<!-- Adding time0/timeN overwrite protection option --> 

## Description
<!--
Make configurable to not have time0 and timeN be over-written by forecast hour 0/N
Is a change of answers expected from this PR? No

Please also include the following information: 
* Matthew 
*  X new feature_
* Are answer changes expected from this PR? No
-->

### Issue(s) addressed
<!--
This PR will eliminate hardcoding similar to what was done for HAFSv2 https://github.com/NOAA-EMC/WW3/pull/965/files
-->

### Commit Message
<!--
time0/timeN overwrite protection option 
-->

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [ ] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [ ] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? This change would not have an effect on the reg tests, and it was tested by running the matrix reg tests. (Matrix12)
* Are the changes covered by regression tests? The changes can be tested within the ufs-weather-model tests.
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? Yes, Hera. 
*
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

